### PR TITLE
#57 不要なcontainerタグを削除

### DIFF
--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -1,8 +1,6 @@
 <template>
 	<sidebar class="sidebar"></sidebar>
-	<v-container class="counter">
-		<router-view></router-view>
-	</v-container>
+	<router-view></router-view>
 </template>
 
 <script>


### PR DESCRIPTION
close #57
不要なv-containerタグを削除したところ、メインエリアの上部余白が消滅したため本Issueはクローズとする。